### PR TITLE
Fix: NameError: name 'dp_profile' is not defined

### DIFF
--- a/validate_datapackage.py
+++ b/validate_datapackage.py
@@ -74,6 +74,7 @@ except KeyError as e:
 try:
     dp_profile = dp['profile']
 except:
+    dp_profile = None
     missing_properties.append('profile')
 # resources
 try:


### PR DESCRIPTION
I got the following error:

```python
Traceback (most recent call last):
  File "datapackage-validation/validate_datapackage.py", line 87, in <module>
    if dp_profile == 'vector-data-resource':
NameError: name 'dp_profile' is not defined
```

If an exception is raised because the `"profile"` is missing, then the variable `dp_profile` is never instanced.
```python
# profile
try:
    dp_profile = dp['profile']
except:
    missing_properties.append('profile')
# [...] snip

# check resources attributes
if dp_resources:
    if dp_profile == 'vector-data-resource':
        for dp_r in dp_resources:
             # etc. [...]
```